### PR TITLE
doc: fix instructions to install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ Binaries using multiple formats are provided in the [release](https://github.com
 This depends on cmake, uuid-dev and libboost-graph-dev
 On Linux:
 ```sh
-sudo make install uuid-dev libboost-graph-dev cmake;
+sudo apt install make uuid-dev libboost-graph-dev cmake default-jdk;
 mkdir build;
 cd build;
 cmake .. -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
- include missed `apt`
- fix order
- include java