### PR TITLE
Build on MacOS

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -38,12 +38,12 @@ jobs:
             test: false
             cmake: "emcmake cmake"
 
-          #- name: "MacOS clang"
-            #os: macos-latest
-            #cc: clang
-            #cxx: clang++
-            #test: true
-            #cmake: cmake
+          - name: "MacOS GCC"
+            os: macos-latest
+            cc: /usr/local/opt/gcc/bin/gcc-11
+            cxx: /usr/local/opt/gcc/bin/g++-11
+            test: true
+            cmake: cmake
 
           #- name: "Windows MSVC"
             #os: windows-latest
@@ -74,9 +74,11 @@ jobs:
         with:
           boost_version: 1.73.0
 
-      - name: "Install boost for macOS"
+      - name: "Install dependencies for macOS"
         if: runner.os == 'macOS'
-        run: brew install boost
+        run: |
+          brew install gcc
+          brew install boost
 
       - name: "Setup Emscripten"
         if: ${{ matrix.cc  == 'emcc' }}

--- a/src/input_output_test.cpp
+++ b/src/input_output_test.cpp
@@ -35,7 +35,7 @@ void ParseDirectoryName(std::string name,
   parts.push_back(name.substr(left, right - left));
 
   *translator_name = parts[0];
-  for(int i = 1; i<parts.size(); ++i) {
+  for (int i = 1; i < parts.size(); ++i) {
     *options += parts[i] + "\n";
   }
 }
@@ -64,17 +64,15 @@ int main(int, const char**) {
       std::string output_computed = translator->Translate(input, options);
 
       if (output_computed == output) {
-        std::cout << "  [PASS] " << test << std::endl;
+        std::cout << "  [PASS] " << test.path() << std::endl;
       } else {
-        std::cout << "  [FAIL] " << test << std::endl;
+        std::cout << "  [FAIL] " << test.path() << std::endl;
         std::cout << "---[Output]------------------" << std::endl;
         std::cout << output_computed << std::endl;
         std::cout << "---[Expected]----------------" << std::endl;
         std::cout << output << std::endl;
         std::cout << "---------------------" << std::endl;
         result = EXIT_FAILURE;
-
-        //std::ofstream(test.path() / "output") << output_computed;
       }
     }
   }


### PR DESCRIPTION
This PR gets Diagon building on my Mac. I had trouble linking `cstd++fs` with clang, but it worked with GCC. I figured that since you already have a GCC target ("Linux GCC") that this would be ok. Let me know if this presents a problem.