### PR TITLE
Download ANTLR4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,9 @@ endif()
 
 FetchContent_Declare(antlr
   GIT_REPOSITORY https://github.com/antlr/antlr4
-  GIT_TAG 4.11.1
+  # GIT_TAG 4.11.1
+  GIT_TAG 1cb4669f84cea5b59661fd44b0f80509fdacd3f9
+  GIT_SHALLOW FALSE
   GIT_PROGRESS TRUE
 )
 


### PR DESCRIPTION
It now links against pthread, and this is not supported directly by emscriten. Downgrading the ANTLR version fixed the problem.

Long-term, I submitted a PR against ANTLR to fix the issue: https://github.com/antlr/antlr4/pull/4086