### PR TITLE
feat: Add Docker builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:24.04 AS builder
+
+ARG ANTLR_VERSION=4.13.2
+ENV ANTLR_VERSION=$ANTLR_VERSION
+
+RUN apt update && \
+    apt install -y make libboost-graph-dev cmake default-jdk git g++ wget
+COPY . /Diagon
+RUN mkdir -p Diagon/build && \
+    cd Diagon/build && \
+    cmake .. -DCMAKE_BUILD_TYPE=Release && \
+    wget -O antlr.jar https://www.antlr.org/download/antlr-$ANTLR_VERSION-complete.jar && \
+    make -j install
+
+FROM ubuntu:24.04 AS runner
+COPY --from=builder /usr/local/bin/diagon /usr/local/bin/diagon
+RUN useradd -u 1101 diagon
+USER 1101
+ENTRYPOINT [ "diagon" ]

--- a/README.md
+++ b/README.md
@@ -658,6 +658,8 @@ docker build -t diagon .
 Once built, the image can be invoked like the binary:
 ```sh
 docker run diagon Math -- "f(x) = 1 + x / (1 + x)"
+
+echo "f(x) = 1 + x / (1 + x)" | docker run -i diagon Math
 ```
             
 # Packaging status

--- a/README.md
+++ b/README.md
@@ -647,6 +647,18 @@ cmake .. -DCMAKE_BUILD_TYPE=Release
 make -j
 sudo make install 
 ```
+
+## Build in Docker
+
+If you have Docker installed, the repository includes a Dockerfile for convenient building:
+```sh
+docker build -t diagon .
+```
+
+Once built, the image can be invoked like the binary:
+```sh
+docker run diagon Math -- "f(x) = 1 + x / (1 + x)"
+```
             
 # Packaging status
 


### PR DESCRIPTION
Hi, big fan of the project.

Adds:
* Basic Dockerfile that builds `diagon` and exposes the binary in a small-ish image (~80MB).
* README section for building and running the image.